### PR TITLE
add request.cookie() and response.cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Set header `If-None-Match`.
 
 Set header `Content-Type`.
 
+#### request().cookie(key, value, options)
+
+Set cookie, uses [cookie.serialize()](https://github.com/jshttp/cookie)
+
+```js
+request('/cookie')
+  .cookie(name, value, options)
+  .then(function (response) {
+    console.info(response.cookies);
+  })
+```
+
 #### request().query(params)
 
 Add query string.
@@ -145,6 +157,15 @@ Get header `ETag`.
 #### response.lastModified
 
 Get header `Last-Modified`.
+
+#### response.cookies
+
+Get cookies
+
+```js
+request('/cookie').then(function (response) {
+  console.info(response.cookies);
+})
 
 #### response.buffer().then( buffer => )
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,6 +4,7 @@ var fs = require('mz/fs');
 var path = require('path');
 var http = require('http');
 var https = require('https');
+var cookie = require('cookie');
 var qs = require('querystring');
 var memo = require('memorizer');
 var status = require('statuses');
@@ -27,8 +28,8 @@ function Request(method, uri, _options) {
   headers['accept-encoding'] = headers['accept-encoding'] || 'gzip';
   headers['user-agent'] = headers['user-agent'] || 'https://github.com/thenables/requisition';
   this._http = options.protocol === 'https:' ? https : http;
-
   this.redirects(options.redirects || 3);
+  this._cookie = '';
   this._redirects = 0;
   this._redirectList = [];
 }
@@ -172,6 +173,23 @@ Request.prototype.ifNoneMatch = function (value) {
 Request.prototype.type = function (type) {
   var type = mime.contentType(type);
   if (type) this.options.headers['content-type'] = type;
+  return this;
+}
+
+/**
+ * Set cookie
+ *
+ * @param {String} key
+ * @param {String} value
+ * @param {Object} options
+ * @api public
+ */
+
+Request.prototype.cookie = function (key, value, options) {
+  var args = Array.prototype.slice.call(arguments);
+  var hdr = cookie.serialize.apply(null, args);
+  this._cookie = this._cookie ? this._cookie + '; ' + hdr : hdr;
+  this.set('Cookie', this._cookie);
   return this;
 }
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -7,6 +7,7 @@ var typeis = require('type-is').is;
 var statuses = require('statuses');
 var typer = require('media-typer');
 var memo = require('memorizer');
+var cookie = require('cookie');
 var zlib = require('zlib');
 var cp = require('fs-cp');
 
@@ -97,6 +98,23 @@ memo(Response.prototype, 'etag', function () {
 memo(Response.prototype, 'lastModified', function () {
   var date = this.get('Last-Modified');
   if (date) return new Date(date);
+})
+
+/**
+ * Get cookies
+ *
+ * @return {Object}
+ * @api public
+ */
+
+memo(Response.prototype, 'cookies', function () {
+  var cookieString = this.get('Set-Cookie');
+
+  if (Array.isArray(cookieString)) {
+    cookieString = cookieString.join(';');
+  }
+
+  if (cookieString) return cookie.parse(cookieString);
 })
 
 // All response methods

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "thenables/requisition",
   "dependencies": {
     "any-promise": "^1.1.0",
+    "cookie": "^0.2.3",
     "destroy": "^1.0.3",
     "fs-cp": "^1.2.0",
     "http-errors": "^1.2.7",
@@ -26,6 +27,7 @@
     "bluebird": "^3.1.1",
     "body-parser": "^1.10.0",
     "concat-stream": "^1.4.7",
+    "cookie-parser": "^1.4.1",
     "express": "^4.9.8",
     "istanbul": "^0.4.2",
     "mocha": "^2.0.0"

--- a/test/request.js
+++ b/test/request.js
@@ -6,6 +6,7 @@ var express = require('express');
 var typer = require('media-typer');
 var bodyParser = require('body-parser');
 var Promise = require('any-promise');
+var cookieParser = require('cookie-parser');
 
 var request = require('..');
 
@@ -267,6 +268,51 @@ describe('Request', function () {
     it('(json)', function () {
       var req = request('http://localhost').type('json');
       assert(req.headers['content-type'].match(/application\/json/));
+    })
+  })
+
+  describe('.cookie', function () {
+    var app = express();
+    app.use(cookieParser());
+    app.use(function (req, res, next) {
+      res.json(req.cookies);
+    })
+
+    it('(key, value)', function () {
+      return new Promise(function (resolve, reject) {
+        app.listen(function (err) {
+          if (err) throw err;
+          resolve(this.address().port);
+        })
+      }).then(function (port) {
+        return request('http://localhost:' + port)
+          .cookie('name', 'test')
+          .cookie('word', 'hello')
+          .then(function (response) {
+            return response.json();
+          })
+      }).then(function (data) {
+        assert.deepEqual(data, { name: 'test', word: 'hello' });
+      })
+    })
+
+    it('(key, value, options)', function () {
+      return new Promise(function (resolve, reject) {
+        app.listen(function (err) {
+          if (err) throw err;
+          resolve(this.address().port);
+        })
+      }).then(function (port) {
+        return request('http://localhost:' + port)
+          .cookie('name', 'test', { path: '/' })
+          .cookie('word', 'hello', { path: '/test' })
+          .then(function (response) {
+            return response.json();
+          })
+      }).then(function (data) {
+        assert.equal(data.name, 'test');
+        assert.equal(data.word, 'hello');
+      })
     })
   })
 

--- a/test/response.js
+++ b/test/response.js
@@ -1,5 +1,6 @@
 
 var Promise = require('any-promise');
+var cookieParser = require('cookie-parser');
 var tmpdir = require('os').tmpdir();
 var cat = require('concat-stream');
 var express = require('express');
@@ -42,7 +43,7 @@ describe('Response', function () {
         })
       }).then(function (port) {
         return request('http://127.0.0.1:' + port).then(function (response) {
-          assert(response.etag, '"test-etag"');
+          assert.equal(response.etag, '"test-etag"');
         })
       })
     })
@@ -83,6 +84,29 @@ describe('Response', function () {
       }).then(function (port) {
         return request('http://127.0.0.1:' + port).then(function (response) {
           assert.equal(response.lastModified.getTime(), lastModified.getTime());
+        })
+      })
+    })
+  })
+
+  describe('.cookies()', function () {
+    it('should get cookies', function () {
+      var app = express();
+      app.use(cookieParser());
+      app.use(function (req, res) {
+        res.cookie('name', 'test');
+        res.cookie('word', 'hello');
+        res.end();
+      })
+      return new Promise(function (resolve, reject) {
+        app.listen(function (err) {
+          if (err) throw err;
+          resolve(this.address().port);
+        })
+      }).then(function (port) {
+        return request('http://127.0.0.1:' + port).then(function (response) {
+          assert.equal(response.cookies.name, 'test');
+          assert.equal(response.cookies.word, 'hello');
         })
       })
     })


### PR DESCRIPTION
not sure is it necessary to handle some edge cases.

such as:
```js
// from express res
res.cookie('name', '1', { domain: '.1.com' });
res.cookie('name', '2', { domain: '.2.com' });
```