### PR TITLE
fix README.md syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Get cookies
 request('/cookie').then(function (response) {
   console.info(response.cookies);
 })
+```
 
 #### response.buffer().then( buffer => )
 


### PR DESCRIPTION
Missing triple backticks (````) resulted in weirdness.